### PR TITLE
Organiser better hidden columns

### DIFF
--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -39,6 +39,40 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DtrRating } from 'app/item-review/dtr-api-types';
 import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 
+// TODO: save in settings and possibly make a type?
+export const initialEnabledColumns = [
+  'selection',
+  'icon',
+  'name',
+  'dmg',
+  'power',
+  'locked',
+  'tag',
+  'wishList',
+  'rating',
+  'archetype',
+  'perks',
+  'mods',
+  'notes'
+];
+
+/**
+ * Figures out the id's of the hidden columns (including sub-columns) for react-table
+ *
+ * @param columns DimColumn[] for react-table
+ * @param enabledColumns string[] of enabled column ids
+ */
+export function getHiddenColumns(columns: DimColumn[], enabledColumns: string[]) {
+  return _.compact(
+    columns.flatMap((c) => {
+      if (c.id && !enabledColumns.includes(c.id)) {
+        const subColumnIds = c.columns?.map((sub) => sub.id) || [];
+        return [c.id, ...subColumnIds];
+      }
+    })
+  );
+}
+
 // TODO: drop wishlist columns if no wishlist loaded
 // TODO: d1/d2 columns
 // TODO: stat ranges

--- a/src/app/organizer/EnabledColumnsSelector.tsx
+++ b/src/app/organizer/EnabledColumnsSelector.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import _ from 'lodash';
 import { DimItem } from 'app/inventory/item-types';
 import { Column } from 'react-table';
 import DropDown, { DropDownItem } from './DropDown';
 import { t } from 'app/i18next-t';
+import { initialEnabledColumns, getHiddenColumns } from './Columns';
 
 /**
  * Component for selection of which columns are displayed in the organizer table.
@@ -16,14 +17,20 @@ import { t } from 'app/i18next-t';
  */
 function EnabledColumnsSelector({
   columns,
-  enabledColumns,
-  onChangeEnabledColumn
+  setHiddenColumns
 }: {
   columns: Column<DimItem>[];
-  enabledColumns: string[];
-  onChangeEnabledColumn(item: { checked: boolean; id: string }): void;
+  setHiddenColumns(hiddenColumns: string[]): void;
 }) {
   const items: DropDownItem[] = [];
+
+  const [enabledColumns, setEnabledColumns] = useState(initialEnabledColumns);
+
+  const onChangeEnabledColumn: (item: { checked: boolean; id: string }) => void = (item) => {
+    const { checked, id } = item;
+    setHiddenColumns(getHiddenColumns(columns, enabledColumns));
+    setEnabledColumns((columns) => (checked ? [...columns, id] : columns.filter((c) => c !== id)));
+  };
 
   for (const column of columns) {
     const { id, Header } = column;

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -145,10 +145,9 @@ function ItemTable({
   }, [wishList, filteredItems, itemInfos, ratings, defs]);
 
   const initialState = {
-    sortBy: [{ id: 'name' }]
+    sortBy: [{ id: 'name' }],
+    hiddenColumns
   };
-
-  hiddenColumns.pop();
 
   // Use the state and functions returned from useTable to build your UI
   const {


### PR DESCRIPTION
This would be my ideal version of hidden columns with the exception that we shouldn't have to pass in all the sub-columns to hide them, just the parent column. Then getHiddenColumns would just be 
`_.difference(columns.map(c => c.id), enabledColumns)`